### PR TITLE
Implement TransactionId and SessionId

### DIFF
--- a/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/converter/EcsAccessConverter.java
+++ b/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/converter/EcsAccessConverter.java
@@ -5,7 +5,6 @@ import com.raynigon.ecs.logging.access.event.EcsAccessLogEvent;
 import com.raynigon.ecs.logging.access.processor.*;
 import com.raynigon.ecs.logging.converter.EventConverter;
 import com.raynigon.ecs.logging.converter.EventConverterHelper;
-import org.apache.catalina.connector.Response;
 import org.springframework.http.HttpHeaders;
 
 import java.time.Instant;
@@ -19,11 +18,12 @@ public class EcsAccessConverter implements EventConverter<IAccessEvent, EcsAcces
 
     public EcsAccessConverter() {
         processors = List.of(
-                new CorrelationIdProcessor(),
                 new DurationProcessor(),
                 new ResponseSizeProcessor(),
                 new ServiceNameProcessor(),
-                new SourceAddressProcessor()
+                new SessionIdProcessor(),
+                new SourceAddressProcessor(),
+                new TransactionIdProcessor()
         );
     }
 

--- a/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/event/EcsAccessLogEvent.java
+++ b/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/event/EcsAccessLogEvent.java
@@ -29,8 +29,11 @@ public final class EcsAccessLogEvent implements EcsLogEvent {
     @JsonProperty("service.name")
     private final String serviceName;
 
-    @JsonProperty("trace.id")
-    private final String traceId;
+    @JsonProperty("transaction.id")
+    private final String transactionId;
+
+    @JsonProperty("session.id")
+    private final String sessionId;
 
     @JsonProperty("source.address")
     private final String sourceAddress;

--- a/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/logback/LogbackAccessValve.java
+++ b/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/logback/LogbackAccessValve.java
@@ -48,18 +48,22 @@ public class LogbackAccessValve extends ValveBase implements AccessValve, Lifecy
 
     @Override
     public void invoke(Request request, Response response) throws IOException, ServletException {
-        String correlationId = request.getHeader(CORRELATION_ID_HEADER);
+        String correlationId = request.getHeader(TRANSACTION_ID_HEADER);
         if (correlationId == null)
             correlationId = UUID.randomUUID().toString();
+        response.addHeader(TRANSACTION_ID_HEADER, correlationId);
 
-        response.addHeader(CORRELATION_ID_HEADER, correlationId);
-
-        MDC.put(CORRELATION_ID_PROPERTY, correlationId);
+        MDC.put(TRANSACTION_ID_PROPERTY, correlationId);
+        String sessionId = request.getHeader(SESSION_ID_HEADER);
+        if (sessionId != null)
+            MDC.put(SESSION_ID_PROPERTY, sessionId);
         Valve next = getNext();
         if (next != null) {
             next.invoke(request, response);
         }
-        MDC.remove(CORRELATION_ID_PROPERTY);
+        if (sessionId != null)
+            MDC.remove(SESSION_ID_PROPERTY);
+        MDC.remove(TRANSACTION_ID_PROPERTY);
     }
 
     @Override

--- a/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/processor/SessionIdProcessor.java
+++ b/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/processor/SessionIdProcessor.java
@@ -3,13 +3,13 @@ package com.raynigon.ecs.logging.access.processor;
 import ch.qos.logback.access.spi.IAccessEvent;
 import com.raynigon.ecs.logging.access.event.EcsAccessLogEvent;
 
-import static com.raynigon.ecs.logging.LoggingConstants.CORRELATION_ID_HEADER;
+import static com.raynigon.ecs.logging.LoggingConstants.SESSION_ID_HEADER;
 
-public class CorrelationIdProcessor implements AccessEventProcessor {
+public class SessionIdProcessor implements AccessEventProcessor {
     @Override
     public EcsAccessLogEvent process(EcsAccessLogEvent result, IAccessEvent event) {
         return result.toBuilder()
-                .traceId(event.getResponseHeader(CORRELATION_ID_HEADER))
+                .sessionId(event.getResponseHeader(SESSION_ID_HEADER))
                 .build();
     }
 }

--- a/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/processor/TransactionIdProcessor.java
+++ b/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/processor/TransactionIdProcessor.java
@@ -1,0 +1,15 @@
+package com.raynigon.ecs.logging.access.processor;
+
+import ch.qos.logback.access.spi.IAccessEvent;
+import com.raynigon.ecs.logging.access.event.EcsAccessLogEvent;
+
+import static com.raynigon.ecs.logging.LoggingConstants.TRANSACTION_ID_HEADER;
+
+public class TransactionIdProcessor implements AccessEventProcessor {
+    @Override
+    public EcsAccessLogEvent process(EcsAccessLogEvent result, IAccessEvent event) {
+        return result.toBuilder()
+                .transactionId(event.getResponseHeader(TRANSACTION_ID_HEADER))
+                .build();
+    }
+}

--- a/ecs-logging-app/src/main/java/com/raynigon/ecs/logging/application/event/EcsApplicationLogEvent.java
+++ b/ecs-logging-app/src/main/java/com/raynigon/ecs/logging/application/event/EcsApplicationLogEvent.java
@@ -27,8 +27,11 @@ public class EcsApplicationLogEvent implements EcsLogEvent {
     @JsonProperty("service.name")
     private final String serviceName;
 
-    @JsonProperty("trace.id")
-    private final String traceId;
+    @JsonProperty("transaction.id")
+    private final String transactionId;
+
+    @JsonProperty("session.id")
+    private final String sessionId;
 
     @JsonProperty("message")
     private final String message;

--- a/ecs-logging-app/src/main/java/com/raynigon/ecs/logging/application/processor/MdcPropertyProcessor.java
+++ b/ecs-logging-app/src/main/java/com/raynigon/ecs/logging/application/processor/MdcPropertyProcessor.java
@@ -6,7 +6,8 @@ import com.raynigon.ecs.logging.application.event.EcsApplicationLogEvent;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.raynigon.ecs.logging.LoggingConstants.CORRELATION_ID_PROPERTY;
+import static com.raynigon.ecs.logging.LoggingConstants.SESSION_ID_PROPERTY;
+import static com.raynigon.ecs.logging.LoggingConstants.TRANSACTION_ID_PROPERTY;
 
 public class MdcPropertyProcessor implements ApplicationEventProcessor {
     @Override
@@ -14,14 +15,23 @@ public class MdcPropertyProcessor implements ApplicationEventProcessor {
         Map<String, String> mdcPropertyMap = event.getMDCPropertyMap();
         if (mdcPropertyMap == null || mdcPropertyMap.isEmpty()) return result;
         Map<String, String> labels = new HashMap<>(mdcPropertyMap);
-        String traceId = null;
-        if (labels.containsKey(CORRELATION_ID_PROPERTY)) {
-            traceId = labels.get(CORRELATION_ID_PROPERTY);
-            labels.remove(CORRELATION_ID_PROPERTY);
-        }
+
+        String transactionId = extractProperty(labels, TRANSACTION_ID_PROPERTY);
+        String sessionId = extractProperty(labels, SESSION_ID_PROPERTY);
+
         return result.toBuilder()
                 .labels(labels)
-                .traceId(traceId)
+                .transactionId(transactionId)
+                .sessionId(sessionId)
                 .build();
+    }
+
+    private String extractProperty(Map<String, String> labels, String property) {
+        String transactionId = null;
+        if (labels.containsKey(property)) {
+            transactionId = labels.get(property);
+            labels.remove(property);
+        }
+        return transactionId;
     }
 }

--- a/ecs-logging-base/src/main/java/com/raynigon/ecs/logging/LoggingConstants.java
+++ b/ecs-logging-base/src/main/java/com/raynigon/ecs/logging/LoggingConstants.java
@@ -5,7 +5,10 @@ public class LoggingConstants {
     public static final String ECS_VERSION = "1.7";
 
     public static final String SERVICE_NAME_PROPERTY = "SERVICE_NAME";
-    public static final String CORRELATION_ID_HEADER = "X-Correlation-ID";
-    public static final String CORRELATION_ID_PROPERTY = "CORRELATION_ID";
+    public static final String TRANSACTION_ID_HEADER = "x-transaction-id";
+    public static final String SESSION_ID_HEADER = "x-session-id";
+
+    public static final String TRANSACTION_ID_PROPERTY = "CORRELATION_ID";
+    public static final String SESSION_ID_PROPERTY = "SESSION_ID";
 
 }

--- a/ecs-logging-base/src/main/java/com/raynigon/ecs/logging/event/EcsLogEvent.java
+++ b/ecs-logging-base/src/main/java/com/raynigon/ecs/logging/event/EcsLogEvent.java
@@ -12,5 +12,7 @@ public interface EcsLogEvent {
 
     String getEventDataset();
 
-    String getTraceId();
+    String getTransactionId();
+
+    String getSessionId();
 }


### PR DESCRIPTION
Fix #17
Fix #18

ECS will add a Session Id in the future.
Therefore we should support a x-session-id header, which is transformed to the session.id field.

Since the ECS Schema uses the field name transaction.id, the header name should be x-transaction-id