### PR TITLE
 Limit Request/Response Body size in Logs

### DIFF
--- a/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/AccessLogProperties.java
+++ b/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/AccessLogProperties.java
@@ -15,4 +15,6 @@ public class AccessLogProperties {
     private List<String> excludeEndpoints = new ArrayList<>();
 
     private boolean exportBody = false;
+
+    private int bodySizeLimit = 10_000;
 }

--- a/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/converter/EcsAccessConverter.java
+++ b/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/converter/EcsAccessConverter.java
@@ -43,7 +43,7 @@ public class EcsAccessConverter implements EventConverter<IAccessEvent, EcsAcces
             return;
         }
         if (properties.isExportBody()) {
-            processors.add(new BodyProcessor());
+            processors.add(new BodyProcessor(properties.getBodySizeLimit()));
         }
     }
 

--- a/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/processor/BodyProcessor.java
+++ b/ecs-logging-access/src/main/java/com/raynigon/ecs/logging/access/processor/BodyProcessor.java
@@ -2,13 +2,29 @@ package com.raynigon.ecs.logging.access.processor;
 
 import ch.qos.logback.access.spi.IAccessEvent;
 import com.raynigon.ecs.logging.access.event.EcsAccessLogEvent;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public class BodyProcessor implements AccessEventProcessor {
+
+    private final int bodySizeLimit;
+
     @Override
     public EcsAccessLogEvent process(EcsAccessLogEvent result, IAccessEvent event) {
+        String requestBody = event.getRequestContent();
+        String responseBody = event.getResponseContent();
+        requestBody = limitSize(requestBody);
+        responseBody = limitSize(responseBody);
+
         return result.toBuilder()
-                .requestBody(event.getRequestContent())
-                .responseBody(event.getResponseContent())
+                .requestBody(requestBody)
+                .responseBody(responseBody)
                 .build();
+    }
+
+    private String limitSize(String body) {
+        if (body == null || body.isEmpty()) return body;
+        if (body.length() <= bodySizeLimit) return body;
+        return body.substring(0, bodySizeLimit);
     }
 }


### PR DESCRIPTION
Implement #109

The exported body size should not exceed 10000 bytes.
If the body is larger than the limit, it should be truncated.